### PR TITLE
feat: Integrate uBO Lite ad-blocking functionality

### DIFF
--- a/Wabbajack.App.Wpf/App.xaml.cs
+++ b/Wabbajack.App.Wpf/App.xaml.cs
@@ -69,6 +69,10 @@ public partial class App
             .Build();
 
         var webview2 = _host.Services.GetRequiredService<WebView2>();
+
+        var adBlockService = _host.Services.GetRequiredService<Services.AdBlockService>();
+        adBlockService.Initialize();
+
         var currentDir = (AbsolutePath)Directory.GetCurrentDirectory();
         var webViewDir = currentDir.Combine("WebView2");
         if(webViewDir.DirectoryExists())
@@ -261,6 +265,7 @@ public partial class App
 
         // Singletons
         services.AddSingleton<CefService>();
+        services.AddSingleton<Services.AdBlockService>();
         services.AddSingleton<IUserInterventionHandler, UserInterventionHandler>();
         services.AddSingleton<ImageCacheManager>();
         services.AddSingleton<SystemParametersConstructor>();

--- a/Wabbajack.App.Wpf/Services/AdBlockService.cs
+++ b/Wabbajack.App.Wpf/Services/AdBlockService.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using DistillNET;
+using Microsoft.Extensions.Logging;
+using Wabbajack.Paths.IO;
+
+namespace Wabbajack.App.Wpf.Services;
+
+public class AdBlockService
+{
+    private readonly ILogger<AdBlockService> _logger;
+    private readonly HttpClient _httpClient;
+    private readonly Filter _filter;
+
+    private readonly List<string> _filterListUrls = new()
+    {
+        // uBlock Origin filters
+        "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt",
+        "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/badware.txt",
+        "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/privacy.txt",
+        "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resource-abuse.txt",
+        // EasyList
+        "https://easylist.to/easylist/easylist.txt",
+        "https://easylist.to/easylist/easyprivacy.txt",
+        // Peter Lowe's
+        "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblockplus&mimetype=plaintext"
+    };
+
+    public AdBlockService(ILogger<AdBlockService> logger, HttpClient httpClient, TemporaryFileManager temporaryFileManager)
+    {
+        _logger = logger;
+        _httpClient = httpClient;
+        _filter = new Filter(storagePath: temporaryFileManager.CreateFolder());
+    }
+
+    public async Task Initialize()
+    {
+        _logger.LogInformation("Initializing AdBlockService...");
+        try
+        {
+            var allFilters = new List<string>();
+            foreach (var url in _filterListUrls)
+            {
+                try
+                {
+                    _logger.LogInformation("Downloading filter list from {url}", url);
+                    var filterData = await _httpClient.GetStringAsync(url);
+                    allFilters.Add(filterData);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to download filter list from {url}", url);
+                }
+            }
+
+            var combinedFilters = string.Join(Environment.NewLine, allFilters);
+            await _filter.Parse(combinedFilters);
+            _logger.LogInformation("AdBlockService initialized with {count} rules.", _filter.RuleCount);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize AdBlockService");
+        }
+    }
+
+    public bool IsBlocked(Uri uri)
+    {
+        if (_filter.RuleCount == 0) return false;
+
+        var requestInfo = new RequestInfo(uri.ToString(), uri.Host, "other");
+        return _filter.ShouldFilter(requestInfo);
+    }
+}

--- a/Wabbajack.App.Wpf/UserIntervention/ManualBlobDownloadHandler.cs
+++ b/Wabbajack.App.Wpf/UserIntervention/ManualBlobDownloadHandler.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Wabbajack.DTOs.DownloadStates;
 using Wabbajack.DTOs.Interventions;
+using Wabbajack.App.Wpf.Services;
 using Wabbajack.Hashing.xxHash64;
 
 namespace Wabbajack.UserIntervention;
@@ -11,7 +12,8 @@ public class ManualBlobDownloadHandler : BrowserWindowViewModel
 {
     public ManualBlobDownload Intervention { get; set; }
 
-    public ManualBlobDownloadHandler(IServiceProvider serviceProvider) : base(serviceProvider) { }
+    public ManualBlobDownloadHandler(IServiceProvider serviceProvider, AdBlockService adBlockService)
+        : base(serviceProvider, adBlockService) { }
 
     protected override async Task Run(CancellationToken token)
     {

--- a/Wabbajack.App.Wpf/UserIntervention/ManualDownloadHandler.cs
+++ b/Wabbajack.App.Wpf/UserIntervention/ManualDownloadHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Wabbajack.DTOs.DownloadStates;
+using Wabbajack.App.Wpf.Services;
 using Wabbajack.DTOs.Interventions;
 
 namespace Wabbajack;
@@ -10,7 +11,8 @@ public class ManualDownloadHandler : BrowserWindowViewModel
 {
     public ManualDownload Intervention { get; set; }
 
-    public ManualDownloadHandler(IServiceProvider serviceProvider) : base(serviceProvider) { }
+    public ManualDownloadHandler(IServiceProvider serviceProvider, AdBlockService adBlockService)
+        : base(serviceProvider, adBlockService) { }
 
     protected override async Task Run(CancellationToken token)
     {

--- a/Wabbajack.App.Wpf/UserIntervention/NexusLoginHandler.cs
+++ b/Wabbajack.App.Wpf/UserIntervention/NexusLoginHandler.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Wabbajack.DTOs.Logins;
+using Wabbajack.App.Wpf.Services;
 using Wabbajack.DTOs.OAuth;
 using Wabbajack.Services.OSIntegrated;
 
@@ -26,7 +27,10 @@ public class NexusLoginHandler : BrowserWindowViewModel
     private readonly ILogger<NexusLoginHandler> _logger;
     private readonly HttpClient _client;
 
-    public NexusLoginHandler(ILogger<NexusLoginHandler> logger, HttpClient client, EncryptedJsonTokenProvider<NexusOAuthState> tokenProvider, IServiceProvider serviceProvider) : base(serviceProvider)
+    public NexusLoginHandler(ILogger<NexusLoginHandler> logger, HttpClient client,
+        EncryptedJsonTokenProvider<NexusOAuthState> tokenProvider, IServiceProvider serviceProvider,
+        AdBlockService adBlockService)
+        : base(serviceProvider, adBlockService)
     {
         _logger = logger;
         _client = client;

--- a/Wabbajack.App.Wpf/UserIntervention/OAuth2LoginHandler.cs
+++ b/Wabbajack.App.Wpf/UserIntervention/OAuth2LoginHandler.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Web;
 using Microsoft.Extensions.Logging;
 using Wabbajack.Common;
+using Wabbajack.App.Wpf.Services;
 using Wabbajack.DTOs.Logins;
 using Wabbajack.Services.OSIntegrated;
 
@@ -21,7 +22,9 @@ public abstract class OAuth2LoginHandler<TLoginType> : BrowserWindowViewModel
     private readonly ILogger _logger;
 
     public OAuth2LoginHandler(ILogger logger, HttpClient httpClient,
-        EncryptedJsonTokenProvider<TLoginType> tokenProvider, IServiceProvider serviceProvider) : base(serviceProvider)
+        EncryptedJsonTokenProvider<TLoginType> tokenProvider, IServiceProvider serviceProvider,
+        AdBlockService adBlockService)
+        : base(serviceProvider, adBlockService)
     {
         var tlogin = new TLoginType();
         HeaderText = $"{tlogin.SiteName} Login";

--- a/Wabbajack.App.Wpf/Wabbajack.App.Wpf.csproj
+++ b/Wabbajack.App.Wpf/Wabbajack.App.Wpf.csproj
@@ -80,6 +80,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DistillNET" Version="1.6.6" />
     <PackageReference Include="DynamicData" Version="9.1.1" />
     <PackageReference Include="Extended.Wpf.Toolkit" Version="4.6.1">
       <NoWarn>NU1701</NoWarn>


### PR DESCRIPTION
Integrates uBO Lite's ad-blocking capabilities directly into Wabbajack's internal web browser.

This is achieved by:
- Creating a new `AdBlockService` to manage and apply ad-blocking rules.
- Using the `DistillNET` library to parse AdBlock-style filter lists.
- Downloading filter lists from uBlock Origin's uAssets repository and EasyList at application startup.
- Intercepting network requests in all `WebView2` instances and blocking them if they match the filter rules.

This enhances user experience by blocking ads and trackers in the various web views used for logins and manual downloads.