### PR TITLE
feat: Comment out unused secrets in tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,8 +18,8 @@ jobs:
     env:
       NEXUS_API_KEY: ${{ secrets.NEXUS_API_KEY }}
       NEXUS_LOGIN: ${{ secrets.NEXUS_LOGIN }}
-      VECTOR_PLEXUS: ${{ secrets.VECTOR_PLEXUS }}
-      LOVERS_LAB: ${{ secrets.LOVERS_LAB }}
+      # VECTOR_PLEXUS: ${{ secrets.VECTOR_PLEXUS }}
+      # LOVERS_LAB: ${{ secrets.LOVERS_LAB }}
     
     strategy:
       matrix:


### PR DESCRIPTION
The VECTOR_PLEXUS and LOVERS_LAB secrets are not required for running the main test suite, as the tests that use them are already commented out. This change comments out the environment variables in the GitHub Actions workflow to prevent issues when these secrets are not available.